### PR TITLE
Fix compatibility issue with ns2plus

### DIFF
--- a/src/lua/LocalTalkExtended/ModsMenuData.lua
+++ b/src/lua/LocalTalkExtended/ModsMenuData.lua
@@ -4,10 +4,10 @@ OP_TT_ColorPicker = OP_TT_ColorPicker or GetMultiWrappedClass(GUIMenuColorPicker
 
 local menu =
 {
-    categoryName = "ns2Plus",
+    categoryName = "localTalk",
     entryConfig =
     {
-        name = "ns2PlusModEntry",
+        name = "localTalkModEntry",
         class = GUIMenuCategoryDisplayBoxEntry,
         params =
         {
@@ -16,7 +16,7 @@ local menu =
     },
     contentsConfig = ModsMenuUtils.CreateBasicModsMenuContents
     {
-        layoutName = "ns2PlusOptions",
+        layoutName = "localTalkOptions",
         contents =
         {
             {


### PR DESCRIPTION
Forgot to rename the mod option entry names. Causes script errors when
the local talk mod is loaded together with ns2plus. The new GUI system
expects unique element names in same GUI group.

Sorry forgot to test with ns2plus enabled. Only tested with shine loaded previously.