### PR TITLE
Add back BindingsDialog modifications

### DIFF
--- a/src/lua/LocalTalkExtended/BindingsDialog.lua
+++ b/src/lua/LocalTalkExtended/BindingsDialog.lua
@@ -1,0 +1,11 @@
+local defaults = debug.getupvaluex(GetDefaultInputValue, "defaults")
+table.insert(defaults, {"LocalVoiceChat", "None"})
+table.insert(defaults, {"LocalVoiceChatTeam", "None"})
+
+local bindings = BindingsUI_GetBindingsData()
+for i, v in ipairs {
+	"LocalVoiceChat",     "input", "Proximity Communication (can be heard by enemy)",     "None",
+	"LocalVoiceChatTeam", "input", "Proximity Communication (can be heard by team only)", "None",
+} do
+	table.insert(bindings, i, v)
+end

--- a/src/lua/LocalTalkExtended/FileHooks.lua
+++ b/src/lua/LocalTalkExtended/FileHooks.lua
@@ -1,5 +1,6 @@
 ModLoader.SetupFileHook("lua/InputHandler.lua", "lua/LocalTalkExtended/InputHandler.lua", "post")
 ModLoader.SetupFileHook("lua/NetworkMessages.lua", "lua/LocalTalkExtended/NetworkMessages.lua", "post")
+ModLoader.SetupFileHook("lua/BindingsDialog.lua", "lua/LocalTalkExtended/BindingsDialog.lua", "post")
 ModLoader.SetupFileHook("lua/menu2/NavBar/Screens/Options/Mods/ModsMenuData.lua", "lua/LocalTalkExtended/ModsMenuData.lua", "post")
 
 ModLoader.SetupFileHook("lua/GUIVoiceChat.lua", "lua/LocalTalkExtended/GUIVoiceChat.lua", "replace")


### PR DESCRIPTION
Fixes script error when GetIsBinding is called before the mod options menu has been loaded.